### PR TITLE
Bonus pool calculations in december

### DIFF
--- a/a_model/datascope.py
+++ b/a_model/datascope.py
@@ -137,8 +137,7 @@ class Datascope(object):
         return yearly_revenue / yearly_billable_hours
 
     def get_cash_buffer(self):
-        _, costs = zip(*self.profit_loss.get_historical_costs())
-        return self.n_months_buffer * sum(costs) / len(costs)
+        return self.n_months_buffer * self.average_historical_costs()
 
     def iter_future_months(self, n_months):
         # can use any report for this. happened to choose unpaid invoices

--- a/a_model/datascope.py
+++ b/a_model/datascope.py
@@ -239,6 +239,8 @@ class Datascope(object):
         revenues = self.simulate_revenues(universe, n_months)
         costs = self.simulate_costs(universe, n_months)
         monthly_cash = []
+        bonus_pool = None
+        quarterly_taxes = dict((month, None) for month in tax_months)
         for month, date in enumerate(self.iter_future_months(n_months)):
 
             # quarterly tax draws only decrease the cash in the bank; they do
@@ -249,37 +251,40 @@ class Datascope(object):
             ytd_profit = ytd_revenue - ytd_cost
             if date.month in tax_months and ytd_profit > 0:
                 quarterly_tax = self.tax_rate * ytd_profit - ytd_tax_draws
-                if quarterly_tax > 0:
-                    cash -= quarterly_tax
-                    ytd_tax_draws += quarterly_tax
-                if date.month == 1:
-                    ytd_tax_draws = 0.0
+                quarterly_tax = max([0.0, quarterly_tax])
+                quarterly_taxes[date.month] = quarterly_tax
+                cash -= quarterly_tax
+                ytd_tax_draws += quarterly_tax
 
-            # pay expenses and put that $$$ in the bank. bonus calculation has
-            # to happen here to have access to the amount of cash in the bank
-            # after taxes for Q4 of the previous year have been drawn. bonus
-            # counts as an expense and reduces our tax burden. taxes have
-            # already been paid on dividends and are just drawn from the bank
-            if date.month == 1:
-                buffer = self.get_cash_buffer()
-                pool = cash - buffer
-                f = self.fraction_profit_for_dividends
-                costs[month] += (1.0 - f) * pool
-                if pool > 0:
-                    cash -= f * pool
+            # pay all normal expenses and add revenues for the month
             cash -= costs[month]
             cash += revenues[month]
+
+            # pay bonuses at the end of December. can instead count this in
+            # January if it looks like Datascope's profits will grow in the
+            # next year, but this gives us the flexibility to pay bonuses early
+            # if appropriate. bonus calculation has to happen here to have
+            # access to the net cash in the bank at the end of the month. bonus
+            # counts as an expense and reduces our tax burden. taxes have
+            # already been paid on dividends and are just drawn from the bank.
+            if date.month == 12:
+                buffer = self.get_cash_buffer()
+                bonus_pool = max([0.0, cash - buffer])
+                f = self.fraction_profit_for_dividends
+                costs[month] += (1.0 - f) * bonus_pool
+                cash -= f * bonus_pool
 
             # reset the ytd calculations as necessary to make the tax
             # calculations correct
             if date.month == 1:
                 ytd_revenue, ytd_cost = 0.0, 0.0
+                ytd_tax_draws = 0.0
             ytd_cost += costs[month]
             ytd_revenue += revenues[month]
 
             # record and return the cash in the bank at the end of the month
             monthly_cash.append(cash)
-        return monthly_cash
+        return monthly_cash, bonus_pool, quarterly_taxes
 
     def simulate_monthly_cash(self, n_months=12, n_universes=1000,
                               verbose=False):
@@ -287,12 +292,17 @@ class Datascope(object):
         month.
         """
         monthly_cash_outputs = []
+        bonus_pool_outputs = []
+        quarterly_taxes_outputs = collections.defaultdict(list)
         for universe in range(n_universes):
             if verbose and universe % 100 == 0:
                 print >> sys.stderr, "simulation %d" % universe
-            monthly_cash_outputs.append(
+            monthly_cash, bonus_pool, quarterly_taxes = \
                 self._simulate_single_universe_monthly_cash(universe, n_months)
-            )
+            monthly_cash_outputs.append(monthly_cash)
+            bonus_pool_outputs.append(bonus_pool)
+            for month in quarterly_taxes:
+                quarterly_taxes_outputs[month].append(quarterly_taxes[month])
         return monthly_cash_outputs
 
     def get_cash_goal_in_month(self, month):

--- a/bin/simulate_bonuses.py
+++ b/bin/simulate_bonuses.py
@@ -23,7 +23,7 @@ args = parser.parse_args()
 datascope = Datascope()
 
 # simulate cashflow for the rest of the year
-monthly_cash_outcomes = datascope.simulate_monthly_cash(
+_, bonus_pool_outcomes, _ = datascope.simulate_monthly_cash(
     n_months=args.n_months,
     n_universes=args.n_universes,
     verbose=args.verbose,
@@ -31,14 +31,10 @@ monthly_cash_outcomes = datascope.simulate_monthly_cash(
 
 # slice the data to get the eoy cash
 eoy = datetime.date(datetime.date.today().year, 12, 31)
-months_until_eoy = datascope.profit_loss.get_months_from_now(eoy)
-cash_buffer = datascope.n_months_buffer * datascope.average_historical_costs()
 person_bonuses = []
-for monthly_cash in monthly_cash_outcomes:
-    eoy_cash = monthly_cash[months_until_eoy]
-    profit = eoy_cash - cash_buffer
+for bonus_pool in bonus_pool_outcomes:
     for person in datascope.iter_people():
-        bonus = max(0, profit * person.net_fraction_of_profits(eoy))
+        bonus = bonus_pool * person.net_fraction_of_profits(eoy)
         person_bonuses.append((person.name.capitalize(), bonus))
 
 # cast the data as a dataframe

--- a/bin/simulate_cash_in_bank.py
+++ b/bin/simulate_cash_in_bank.py
@@ -29,11 +29,14 @@ datascope = Datascope()
 historical_cash_in_bank = datascope.balance_sheet.get_historical_cash_in_bank()
 
 # simulate cashflow for the rest of the year
-monthly_cash_outcomes = datascope.simulate_monthly_cash(
+outcomes = datascope.simulate_monthly_cash(
     n_months=args.n_months,
     n_universes=args.n_universes,
     verbose=args.verbose,
 )
+monthly_cash_outcomes = outcomes[0]
+bonus_pool_outcomes = outcomes[1]
+quarterly_tax_outcomes = outcomes[2]
 
 # transform the data in a convenient way for plotting
 historical_t, historical_cash = zip(*historical_cash_in_bank)
@@ -112,7 +115,7 @@ plt.ylabel('cash in bank')
 eoy = datetime.date(datetime.date.today().year, 12, 31)
 months_until_eoy = datascope.profit_loss.get_months_from_now(eoy)
 outcomes = datascope.get_outcomes_in_month(
-    months_until_eoy, monthly_cash_outcomes
+    months_until_eoy, monthly_cash_outcomes,
 )
 
 # outcome labels
@@ -166,7 +169,16 @@ for tic in ax.xaxis.get_major_ticks():
 for tic in ax.yaxis.get_major_ticks():
     tic.tick2On = False
 
-# other labels
+# save results to file and print a few other useful summary statistics
 filename = 'cash_in_bank.png'
 plt.savefig(filename)
 print "results now available in", filename
+print "2.5/50/97.5 percentile bonus pool size:", \
+    numpy.percentile(bonus_pool_outcomes, 2.5), \
+    numpy.percentile(bonus_pool_outcomes, 50), \
+    numpy.percentile(bonus_pool_outcomes, 97.5)
+for month, values in sorted(quarterly_tax_outcomes.iteritems()):
+    print "2.5/50/97.5 percentile tax draw in month %d:" % month, \
+        numpy.percentile(values, 2.5), \
+        numpy.percentile(values, 50), \
+        numpy.percentile(values, 97.5)

--- a/bin/simulate_hiring_risk.py
+++ b/bin/simulate_hiring_risk.py
@@ -29,7 +29,7 @@ def get_all_n00b_outcomes():
     for n00b in range(0, args.n_n00bs+1):
         if n00b > 0:
             datascope.add_person("n00b_%d" % n00b)
-        monthly_cash_outputs = datascope.simulate_monthly_cash(
+        monthly_cash_outputs, _, _ = datascope.simulate_monthly_cash(
             n_months=args.n_months,
             n_universes=args.n_universes,
             verbose=args.verbose,


### PR DESCRIPTION
We're now calculating our costs as if bonuses are delivered in December. We will still have flexibility to defer paying bonuses until January if that is tax advantageous, but now the bonus calculation happens at the same time the simulations are run so its a little cleaner to analyze for various things.
